### PR TITLE
Dependency update (#37)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-record-import-importer",
-	"version": "1.0.6-alpha.1",
+	"version": "1.0.6-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-importer",
-			"version": "1.0.6-alpha.1",
+			"version": "1.0.6-alpha.2",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.23.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@natlibfi/melinda-commons": "^13.0.12",
 				"@natlibfi/melinda-record-import-commons": "^10.2.2",
 				"@natlibfi/melinda-rest-api-client": "^4.0.3",
-				"@natlibfi/melinda-rest-api-commons": "^4.1.2-alpha.1",
+				"@natlibfi/melinda-rest-api-commons": "^4.1.3",
 				"amqplib": "^0.10.3",
 				"http-status": "^1.7.3",
 				"pretty-print-ms": "^1.0.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-record-import-importer",
-	"version": "1.0.5-alpha.7",
+	"version": "1.0.6-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-importer",
-			"version": "1.0.5-alpha.7",
+			"version": "1.0.6-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.23.9",
@@ -15,7 +15,7 @@
 				"@natlibfi/melinda-commons": "^13.0.12",
 				"@natlibfi/melinda-record-import-commons": "^10.2.2",
 				"@natlibfi/melinda-rest-api-client": "^4.0.3",
-				"@natlibfi/melinda-rest-api-commons": "^4.1.1",
+				"@natlibfi/melinda-rest-api-commons": "^4.1.2-alpha.1",
 				"amqplib": "^0.10.3",
 				"http-status": "^1.7.3",
 				"pretty-print-ms": "^1.0.5"
@@ -2972,14 +2972,14 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "10.15.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-10.15.5.tgz",
-			"integrity": "sha512-brLT0G2xWI7Y9xQEyoBLJ9YwaXqXH6F9AbZaxi/oS6nMKk/Vp4JQfUtTrEY0v1IocvtsJV1DlBuF0zAVs5BaZA==",
+			"version": "10.16.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-10.16.0.tgz",
+			"integrity": "sha512-z7BnRVltqEiK6zu/fGHZdEFvKTZ8A04s9zXrmzX+qZjdPW2VLbiDXLaaSuErs8snnb2Uu7LAAoXkqaGn7kyixQ==",
 			"dependencies": {
 				"@babel/register": "^7.23.7",
 				"@natlibfi/issn-verify": "^1.0.3",
 				"@natlibfi/marc-record": "^8.1.0",
-				"@natlibfi/marc-record-validate": "^8.0.5",
+				"@natlibfi/marc-record-validate": "^8.0.6",
 				"cld3-asm": "^3.1.1",
 				"clone": "^2.1.2",
 				"debug": "^4.3.4",
@@ -2992,7 +2992,7 @@
 				"node": ">=18"
 			},
 			"peerDependencies": {
-				"@natlibfi/marc-record-validate": "^8.0.5"
+				"@natlibfi/marc-record-validate": "^8.0.6"
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
@@ -3036,9 +3036,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-import-commons": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-10.2.2.tgz",
-			"integrity": "sha512-UccD3R6A9+w1k2i6tSvw8NnFdde3FgGlL3rv343GjG8Eve2Z1JOK7gjLdQqL+nuKloicJNSgO3i469OEFcwqcg==",
+			"version": "10.2.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-10.2.3.tgz",
+			"integrity": "sha512-C6PWuP3bAVVZWY3iCW8UFyYUyz61H3MzoxpguJTXhZJln+9uOeB3+fH5K++wa/cfVBE+U9hjTpICD1D2V8gKzw==",
 			"dependencies": {
 				"@natlibfi/melinda-backend-commons": "^2.2.1",
 				"@natlibfi/melinda-commons": "^13.0.6",
@@ -3085,16 +3085,16 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.1.tgz",
-			"integrity": "sha512-fyjM5fzb6myAxKkAkmDhm/0yOcTKSyK9aZngijszNs4aG/LJYaMaxFOwsRaMoA2sckIKlWmMikpofhEwu2gHog==",
+			"version": "4.1.2-alpha.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.2-alpha.1.tgz",
+			"integrity": "sha512-N3MdSurZhwCQqMzsegJ4T05vdgTtlP2VDpQb+WQd07X0+xHjQnaLjZBl5S8TItOdVwT0uEmoaLSVzyIlIu9cPQ==",
 			"dependencies": {
-				"@natlibfi/marc-record": "^8.0.2",
+				"@natlibfi/marc-record": "^8.1.0",
 				"@natlibfi/marc-record-serializers": "^10.1.2",
-				"@natlibfi/marc-record-validate": "^8.0.4",
-				"@natlibfi/marc-record-validators-melinda": "^10.15.2",
-				"@natlibfi/melinda-backend-commons": "^2.2.5",
-				"@natlibfi/melinda-commons": "^13.0.10",
+				"@natlibfi/marc-record-validate": "^8.0.6",
+				"@natlibfi/marc-record-validators-melinda": "^10.16.0",
+				"@natlibfi/melinda-backend-commons": "^2.2.6",
+				"@natlibfi/melinda-commons": "^13.0.12",
 				"amqplib": "^0.10.3",
 				"debug": "^4.3.4",
 				"http-status": "^1.7.3",
@@ -6660,10 +6660,22 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/ip": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-			"integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+		"node_modules/ip-address": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+			"integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ip-address/node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
 		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.2",
@@ -7171,9 +7183,9 @@
 			"integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
 		},
 		"node_modules/isbn3": {
-			"version": "1.1.44",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.44.tgz",
-			"integrity": "sha512-lHwBx85hTHPwtSHrieC+AG73doLOIpNbb6OEchh3v2MZrxKJ+HN24ksgparYjRRgNtzVxzuNQd8VBZMEBxcMBw==",
+			"version": "1.1.45",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-1.1.45.tgz",
+			"integrity": "sha512-9oD3yItVFRlYhm/K6RI2K6f+Dti0unzG74X9I7D+xVKMK3TbRl2PMvnWgK6scKnvk4t0BZFyNIznX4H45RrwzQ==",
 			"bin": {
 				"isbn": "bin/isbn",
 				"isbn-audit": "bin/isbn-audit",
@@ -7387,6 +7399,11 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
+		},
+		"node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
 		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
@@ -7699,9 +7716,9 @@
 			}
 		},
 		"node_modules/mocha": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
-			"integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-10.3.0.tgz",
+			"integrity": "sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==",
 			"dev": true,
 			"dependencies": {
 				"ansi-colors": "4.1.1",
@@ -7711,13 +7728,12 @@
 				"diff": "5.0.0",
 				"escape-string-regexp": "4.0.0",
 				"find-up": "5.0.0",
-				"glob": "7.2.0",
+				"glob": "8.1.0",
 				"he": "1.2.0",
 				"js-yaml": "4.1.0",
 				"log-symbols": "4.1.0",
 				"minimatch": "5.0.1",
 				"ms": "2.1.3",
-				"nanoid": "3.3.3",
 				"serialize-javascript": "6.0.0",
 				"strip-json-comments": "3.1.1",
 				"supports-color": "8.1.1",
@@ -7732,10 +7748,6 @@
 			},
 			"engines": {
 				"node": ">= 14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mochajs"
 			}
 		},
 		"node_modules/mocha/node_modules/argparse": {
@@ -7784,45 +7796,22 @@
 			}
 		},
 		"node_modules/mocha/node_modules/glob": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-			"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
 			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
 				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/mocha/node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/mocha/node_modules/has-flag": {
@@ -7878,18 +7867,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
-		},
-		"node_modules/mocha/node_modules/nanoid": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-			"integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-			"dev": true,
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
 		},
 		"node_modules/mocha/node_modules/p-limit": {
 			"version": "3.1.0",
@@ -9257,15 +9234,15 @@
 			"dev": true
 		},
 		"node_modules/socks": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-			"integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+			"integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
 			"dependencies": {
-				"ip": "^2.0.0",
+				"ip-address": "^9.0.5",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
-				"node": ">= 10.13.0",
+				"node": ">= 10.0.0",
 				"npm": ">= 3.0.0"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -3085,9 +3085,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "4.1.2-alpha.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.2-alpha.1.tgz",
-			"integrity": "sha512-N3MdSurZhwCQqMzsegJ4T05vdgTtlP2VDpQb+WQd07X0+xHjQnaLjZBl5S8TItOdVwT0uEmoaLSVzyIlIu9cPQ==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-4.1.3.tgz",
+			"integrity": "sha512-fu1FjzdwUWbLVB7i1GsuIE5/LmYOPuNtuE9uId18rGG+roDAto+VzRCpK/iZd3UgYqMryaeSGFCroKJCIWldZA==",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.1.0",
 				"@natlibfi/marc-record-serializers": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-importer.git"
 	},
 	"license": "MIT",
-	"version": "1.0.5-alpha.7",
+	"version": "1.0.6-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"
@@ -41,7 +41,7 @@
 		"@natlibfi/melinda-commons": "^13.0.12",
 		"@natlibfi/melinda-record-import-commons": "^10.2.2",
 		"@natlibfi/melinda-rest-api-client": "^4.0.3",
-		"@natlibfi/melinda-rest-api-commons": "^4.1.1",
+		"@natlibfi/melinda-rest-api-commons": "^4.1.2-alpha.1",
 		"amqplib": "^0.10.3",
 		"http-status": "^1.7.3",
 		"pretty-print-ms": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"@natlibfi/melinda-commons": "^13.0.12",
 		"@natlibfi/melinda-record-import-commons": "^10.2.2",
 		"@natlibfi/melinda-rest-api-client": "^4.0.3",
-		"@natlibfi/melinda-rest-api-commons": "^4.1.2-alpha.1",
+		"@natlibfi/melinda-rest-api-commons": "^4.1.3",
 		"amqplib": "^0.10.3",
 		"http-status": "^1.7.3",
 		"pretty-print-ms": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-importer.git"
 	},
 	"license": "MIT",
-	"version": "1.0.6-alpha.1",
+	"version": "1.0.6-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"


### PR DESCRIPTION
* Bump the development-dependencies group with 1 update (#36) Bumps the development-dependencies group with 1 update: [mocha](https://github.com/mochajs/mocha).

* Bump the production-dependencies group with 1 update (#35) Bumps the production-dependencies group with 1 update: [@natlibfi/melinda-record-import-commons](https://github.com/natlibfi/melinda-record-import-commons-js).

* Update deps

* 1.0.6-alpha.1