### PR TITLE
Dependency update (#162)

### DIFF
--- a/.github/workflows/melinda-node-tests.yml
+++ b/.github/workflows/melinda-node-tests.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: nodejsscan scan
       id: njsscan
       uses: ajinabraham/njsscan-action@master
@@ -48,7 +48,7 @@ jobs:
     container: docker://node:22
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: mikaelvesavuori/license-compliance-action@v1
         with:
           exclude_pattern: /^@natlibfi/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ Record importer for the Melinda record batch import system.
 
 ## License and copyright
 
-Copyright (c) 2019-2023 **University Of Helsinki (The National Library Of Finland)**
+Copyright (c) 2019-2023, 2026 **University Of Helsinki (The National Library Of Finland)**
 
 [MIT](https://choosealicense.com/licenses/mit/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,48 +1,49 @@
 {
 	"name": "@natlibfi/melinda-record-import-importer",
-	"version": "1.0.7-alpha.1",
+	"version": "1.0.8-alpha.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-import-importer",
-			"version": "1.0.7-alpha.1",
+			"version": "1.0.8-alpha.3",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.0",
-				"@natlibfi/melinda-backend-commons": "^3.0.0",
-				"@natlibfi/melinda-commons": "^14.0.0",
-				"@natlibfi/melinda-record-import-commons": "^13.0.0",
-				"@natlibfi/melinda-rest-api-client": "^6.0.0",
-				"@natlibfi/melinda-rest-api-commons": "^5.0.0",
-				"amqplib": "^0.10.9",
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/melinda-backend-commons": "^3.0.5",
+				"@natlibfi/melinda-commons": "^14.0.2",
+				"@natlibfi/melinda-record-import-commons": "^13.0.3",
+				"@natlibfi/melinda-rest-api-client": "^6.0.3",
+				"@natlibfi/melinda-rest-api-commons": "^5.0.6",
+				"amqplib": "^1.0.2",
+				"debug": "^4.4.3",
 				"http-status": "^2.1.0"
 			},
 			"bin": {
 				"melinda-record-import-importer": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@natlibfi/fixugen": "^3.0.0",
-				"@natlibfi/fixugen-http-client": "^4.0.0",
-				"@natlibfi/fixura": "^4.0.0",
-				"@natlibfi/fixura-mongo": "^3.0.0",
-				"@onify/fake-amqplib": "^3.2.0",
+				"@natlibfi/fixugen": "^3.0.1",
+				"@natlibfi/fixugen-http-client": "^4.0.3",
+				"@natlibfi/fixura": "^4.0.1",
+				"@natlibfi/fixura-mongo": "^3.0.3",
+				"@onify/fake-amqplib": "^3.4.0",
 				"cross-env": "^10.1.0",
-				"esbuild": "^0.27.0",
-				"eslint": "^9.39.1",
-				"nock": "^14.0.10"
+				"esbuild": "^0.27.4",
+				"eslint": "^10.1.0",
+				"nock": "^14.0.11"
 			},
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.4.tgz",
-			"integrity": "sha512-h7iEYiW4HebClDEhtvFObtPmIvrd1SSfpI9EhOeKk4CtIK/ngBWFpuhCzhdmRKtg71ylcue+9I6dv54XYO1epQ==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+			"integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
 			"license": "MIT",
 			"dependencies": {
-				"core-js-pure": "^3.43.0"
+				"core-js-pure": "^3.48.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -76,9 +77,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
-			"integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+			"integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
 			"cpu": [
 				"ppc64"
 			],
@@ -93,9 +94,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
-			"integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+			"integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
 			"cpu": [
 				"arm"
 			],
@@ -110,9 +111,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
-			"integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+			"integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
 			"cpu": [
 				"arm64"
 			],
@@ -127,9 +128,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
-			"integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+			"integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
 			"cpu": [
 				"x64"
 			],
@@ -144,9 +145,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
-			"integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+			"integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -161,9 +162,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
-			"integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+			"integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
 			"cpu": [
 				"x64"
 			],
@@ -178,9 +179,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
-			"integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
 			"cpu": [
 				"arm64"
 			],
@@ -195,9 +196,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
-			"integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+			"integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
 			"cpu": [
 				"x64"
 			],
@@ -212,9 +213,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
-			"integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+			"integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
 			"cpu": [
 				"arm"
 			],
@@ -229,9 +230,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
-			"integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+			"integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
 			"cpu": [
 				"arm64"
 			],
@@ -246,9 +247,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
-			"integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+			"integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
 			"cpu": [
 				"ia32"
 			],
@@ -263,9 +264,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
-			"integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+			"integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
 			"cpu": [
 				"loong64"
 			],
@@ -280,9 +281,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
-			"integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+			"integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -297,9 +298,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
-			"integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+			"integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -314,9 +315,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
-			"integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+			"integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -331,9 +332,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
-			"integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+			"integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
 			"cpu": [
 				"s390x"
 			],
@@ -348,9 +349,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
-			"integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+			"integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
 			"cpu": [
 				"x64"
 			],
@@ -365,9 +366,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
-			"integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -382,9 +383,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
-			"integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
 			"cpu": [
 				"x64"
 			],
@@ -399,9 +400,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
-			"integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+			"integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
 			"cpu": [
 				"arm64"
 			],
@@ -416,9 +417,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
-			"integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+			"integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
 			"cpu": [
 				"x64"
 			],
@@ -433,9 +434,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
-			"integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+			"integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
 			"cpu": [
 				"arm64"
 			],
@@ -450,9 +451,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
-			"integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+			"integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
 			"cpu": [
 				"x64"
 			],
@@ -467,9 +468,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
-			"integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+			"integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
 			"cpu": [
 				"arm64"
 			],
@@ -484,9 +485,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
-			"integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+			"integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
 			"cpu": [
 				"ia32"
 			],
@@ -501,9 +502,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
-			"integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+			"integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
 			"cpu": [
 				"x64"
 			],
@@ -518,9 +519,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-			"integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -560,105 +561,68 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-			"integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+			"version": "0.23.3",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+			"integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^2.1.7",
+				"@eslint/object-schema": "^3.0.3",
 				"debug": "^4.3.1",
-				"minimatch": "^3.1.2"
+				"minimatch": "^10.2.4"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+			"integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.17.0"
+				"@eslint/core": "^1.1.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+			"integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/@eslint/eslintrc": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ajv": "^6.12.4",
-				"debug": "^4.3.2",
-				"espree": "^10.0.1",
-				"globals": "^14.0.0",
-				"ignore": "^5.2.0",
-				"import-fresh": "^3.2.1",
-				"js-yaml": "^4.1.0",
-				"minimatch": "^3.1.2",
-				"strip-json-comments": "^3.1.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/@eslint/js": {
-			"version": "9.39.1",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-			"integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://eslint.org/donate"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+			"integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+			"integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^0.17.0",
+				"@eslint/core": "^1.1.1",
 				"levn": "^0.4.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@humanfs/core": {
@@ -714,18 +678,18 @@
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.2.tgz",
-			"integrity": "sha512-QgA5AySqB27cGTXBFmnpifAi7HxoGUeezwo6p9dI03MuDB6Pp33zgclqVb6oVK3j6I9Vesg0+oojW2XxB59SGg==",
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
+			"integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
 			"license": "MIT",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
 			}
 		},
 		"node_modules/@mswjs/interceptors": {
-			"version": "0.39.8",
-			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.8.tgz",
-			"integrity": "sha512-2+BzZbjRO7Ct61k8fMNHEtoKjeWI9pIlHFTqBwZ5icHpqszIgEZbjb1MW5Z0+bITTCTl3gk4PDBxs9tA/csXvA==",
+			"version": "0.41.3",
+			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+			"integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -741,80 +705,82 @@
 			}
 		},
 		"node_modules/@natlibfi/fixugen": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-3.0.0.tgz",
-			"integrity": "sha512-eIAgelM3iYqE/UHfe5Jx1mk1lW+nkKPsE5BFpgiDqUy88kwAW7qL3c4nvD19FCInixZl5965QAjOIivkJiKWKg==",
-			"dev": true,
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-3.0.1.tgz",
+			"integrity": "sha512-KoWcTmWvE91A5JJ5z5K1bH0j3LJgu8HnCGvtMWzzo3JX5u5n4Xux+ymxb79GWJFWswC/3CHNP2Z0BDvy7RD/+w==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/fixura": "^4.0.0"
+				"@natlibfi/fixura": "^4.0.1"
 			},
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@natlibfi/fixugen-http-client": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen-http-client/-/fixugen-http-client-4.0.0.tgz",
-			"integrity": "sha512-SWoQxNWzbUjUBpDbw5OmvBxZVasHOhPOt9zrKvV+ZzxTFq+XpMAr1xidYpRTlEHWNcnToWjivXZrEdwEjnxu1A==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen-http-client/-/fixugen-http-client-4.0.3.tgz",
+			"integrity": "sha512-xymWlWMWFNY0kqPKRBah0nDKmwsEtjIhKA1VjTFc2+ITYd33KJbtuOQExXY+Q9dZ5P3wGQsIppHMFVGONfjtoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/fixugen": "^3.0.0",
-				"@natlibfi/fixura": "^4.0.0",
-				"nock": "^14.0.5"
+				"@natlibfi/fixugen": "^3.0.1",
+				"@natlibfi/fixura": "^4.0.1",
+				"debug": "^4.4.3",
+				"nock": "^14.0.11"
 			},
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@natlibfi/fixura": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-4.0.0.tgz",
-			"integrity": "sha512-ONxPpEQtfu9K9K8KIjcB+ggRW4Tcc4YFe34Dzm+NeAbAFEP/QFlChoV8wlVFfE20o9kLIJijNN3wT90y7GTGQg==",
-			"dev": true,
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-4.0.1.tgz",
+			"integrity": "sha512-Qm595tV2j8pnPxzxcZK9J88MthZhGfrNvHkWKLY3Ib1Lj3ubVQjK2FPvu0PHHMk3Ulcb+icST3fDsE7x7ozhpQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@natlibfi/fixura-mongo": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixura-mongo/-/fixura-mongo-3.0.0.tgz",
-			"integrity": "sha512-WU0RVmGgbeebTBOd9b/wWuHLBZi8kbqmP6pGZfp/ucyTEtffdwO3rM5MKgPDM9l5kaErwZTqPx5uSPMST6KmJw==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixura-mongo/-/fixura-mongo-3.0.3.tgz",
+			"integrity": "sha512-j7iomX4ig53dtk2WrTEPnl4AGwazX9zEkKhoCwM404f+P6rsCG8RMJT40quupV8CS8gdwcVyiGU7pIM8BAJ1MQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/fixura": "^4.0.0",
-				"mongodb": "^6.20.0",
-				"mongodb-memory-server": "^10.3.0"
+				"@natlibfi/fixura": "^4.0.1",
+				"mongodb": "^6.21.0",
+				"mongodb-memory-server": "^10.4.3"
 			},
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@natlibfi/iso9-1995": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/iso9-1995/-/iso9-1995-1.0.0.tgz",
-			"integrity": "sha512-EtjVec2vZlJon/7xB9p94PrMgBUzV6iZoFTQChX+ZYBC1+nXCtEjOr/aVBJLUXTjUZdt6RXqb6ec2fI8YxUbEw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/iso9-1995/-/iso9-1995-1.1.1.tgz",
+			"integrity": "sha512-OmK3ph9s55nISjhkWK0Jk63geZUjxbKULwmFtiBdTpY2mAAVxckXhG442DJYwlj93IFdzbHxpknwrZVIc0bhIg==",
 			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3"
+			},
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@natlibfi/issn-verify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/issn-verify/-/issn-verify-2.0.0.tgz",
-			"integrity": "sha512-XnzPd4etQTg+D8OOsSI3Q4J8nYlP8V+e3Hp+JD0F1AeNNTjkoVE45o/2iIGt9dvwH3z4LDAbhZ+PpL+gJtYRNw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/issn-verify/-/issn-verify-2.0.2.tgz",
+			"integrity": "sha512-2/HfVM6FdhE3MbsH1M+X3PQ24emnAjf5U4xQexMmZfdPNwOCLxTI2KZBRiJmzWllPXSTcPy/b2mrNtBZBU+YIw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-10.0.0.tgz",
-			"integrity": "sha512-675EZoyFhtL0YQzPDZOlcncZIjwXKa4QzaWoIg8MordC8mYaogJ0Xb4vGOeGglRVpvFA5ZwadgMs07EaJ+Cymw==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-10.0.1.tgz",
+			"integrity": "sha512-ENEMr0sMyM/LUViZ/+/SKQq/u9gju8GBKY4Rx+NsQ1JhV69F0/YbURropawG6eZHZJx0IlO7ncYZPJ6DfqWFHQ==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.3",
@@ -825,12 +791,12 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
-			"version": "11.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-11.0.0.tgz",
-			"integrity": "sha512-bl2Dtq9DgKPuh/h999a0q8IEfHWENaoGxZMDS/JP3OHrPqswnfA0k/xx1R9aCxccP8sViuPpdyCaerebxkBGUQ==",
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-11.0.1.tgz",
+			"integrity": "sha512-pIGJy/PGf7Sjkhh/AuNiKaltOzN7eyK0rt7vCayG8fPv5fQxAlP3Z8mC0CM62OKNetF+zHif5hXUxqPdKG6dJg==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.0",
+				"@natlibfi/marc-record": "^10.0.1",
 				"@xmldom/xmldom": "^0.9.8",
 				"stream-json": "^1.9.1",
 				"xml2js": "^0.6.2",
@@ -856,25 +822,23 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.0.tgz",
-			"integrity": "sha512-Oawg1zm8zg6Z6nn0NjD7W/PVWJFEv5EdFp40/pG9N3oHJOnhryyH64qz/8mcyc6MkyR+tmWk38uEsvPe2et8vg==",
+			"version": "12.0.11",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.11.tgz",
+			"integrity": "sha512-DrdlWIFVWJL4vVv4wgLs/Vx5Uvhpmpdh2wylqeOg/L8fAg0sOIPN05QChOXNyvb5PuGTJxV+ZxiF6Bw6VCJMMw==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/iso9-1995": "^1.0.0",
-				"@natlibfi/issn-verify": "^2.0.0",
-				"@natlibfi/marc-record": "^10.0.0",
-				"@natlibfi/marc-record-serializers": "^11.0.0",
+				"@natlibfi/iso9-1995": "^1.1.1",
+				"@natlibfi/issn-verify": "^2.0.2",
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record-serializers": "^11.0.1",
 				"@natlibfi/marc-record-validate": "^9.0.0",
-				"@natlibfi/melinda-commons": "^14.0.0",
+				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/sfs-4900": "^2.0.0",
-				"@natlibfi/sru-client": "^7.0.0",
-				"cld3-asm": "^4.0.0",
+				"@natlibfi/sru-client": "^7.0.1",
 				"clone": "^2.1.2",
 				"debug": "^4.4.3",
-				"isbn3": "^2.0.0",
-				"langs": "^2.0.0",
-				"undici": "^7.16.0",
+				"franc": "^6.2.0",
+				"isbn3": "^2.0.6",
 				"xml2js": "^0.6.2",
 				"xregexp": "^5.1.2"
 			},
@@ -886,9 +850,9 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-3.0.0.tgz",
-			"integrity": "sha512-UhHV1TIpgPAFKRTJaGH3j7NIprT3adrw/k+mXiL0d79PH0NHBr+yi0yL8iZ3fnwqp1hIOOJjJ0CAKCk0YOxKAQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-3.0.5.tgz",
+			"integrity": "sha512-dS79RyDqPwXIDsTO+9TWfhOu1/R9F/54QJTi4W6ZQCPOOOp5iy4/WUjj7yduqhL1pIPhxdYzDYDv6Jv596JRLw==",
 			"license": "MIT",
 			"dependencies": {
 				"base64-url": "^2.3.3",
@@ -896,8 +860,8 @@
 				"express-winston": "^4.2.0",
 				"html-to-text": "^9.0.5",
 				"moment": "^2.30.1",
-				"nodemailer": "^7.0.10",
-				"winston": "^3.18.3",
+				"nodemailer": "^8.0.4",
+				"winston": "^3.19.0",
 				"yargs": "^18.0.0"
 			},
 			"bin": {
@@ -910,14 +874,14 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-commons": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-14.0.0.tgz",
-			"integrity": "sha512-z6p4WJ2POG9qJ+K5X0LisLwnSQ/Lo89LodyL4DTCZq3i1EYPkl1IKq5anCEGdPUMlHbTDFIx5W554Junq1FugQ==",
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-commons/-/melinda-commons-14.0.2.tgz",
+			"integrity": "sha512-Q8Lx4A1I17Hya2vwlSOgfCRC63PFA3+3fjMQjgkyX3Wt1x4ATmbx18kJ9ecYtiZKqBTHm1qChrXsWAoVQ69Ewg==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.0",
-				"@natlibfi/marc-record-serializers": "^11.0.0",
-				"@natlibfi/sru-client": "^7.0.0",
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record-serializers": "^11.0.1",
+				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -925,18 +889,20 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-record-import-commons": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-13.0.0.tgz",
-			"integrity": "sha512-HgnlZ4IXYSm4CDgurHJbbnlaZa78nH9gUDeLujEnaa115Byy81vzl8UDeIA2gCHNBBYx4xa6jI7Q+QYfYOfQXQ==",
+			"version": "13.0.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-record-import-commons/-/melinda-record-import-commons-13.0.3.tgz",
+			"integrity": "sha512-sk+EX/TiEtZ9fNapqOTtartY4Yaw/HUHeVFi43wvknoSoKpCpLlH9RlZBzDCw7jWdUc/QMZCGywaDXUZeSk1+w==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/melinda-backend-commons": "^3.0.0",
-				"@natlibfi/melinda-commons": "^14.0.0",
+				"@natlibfi/fixugen": "^3.0.0",
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/melinda-backend-commons": "^3.0.4",
+				"@natlibfi/melinda-commons": "^14.0.2",
 				"date-fns": "^4.1.0",
 				"debug": "^4.4.3",
 				"http-status": "^2.1.0",
 				"mongo-sanitize": "^1.1.0",
-				"mongodb": "^6.20.0",
+				"mongodb": "^6.21.0",
 				"openid-client": "^6.8.1",
 				"uuid": "^13.0.0"
 			},
@@ -945,14 +911,14 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-client": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-client/-/melinda-rest-api-client-6.0.0.tgz",
-			"integrity": "sha512-3loxxutjkKQSuGZhVmp0N0RIz0pAOz62ry81UDuQWoHJD2gaW/l7pr3rm0pkUly/sqfIGWDqrw8/Mt1l7CCkRg==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-client/-/melinda-rest-api-client-6.0.3.tgz",
+			"integrity": "sha512-BVfxSNX+dvfim7pTugiExyX+ZdPYGjS9NKb0OpHE8urgpJ2K79KWGoYv89fYbRdoZNVhiccLeW3cZ/8fXZbp5Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.0",
-				"@natlibfi/melinda-backend-commons": "^3.0.0",
-				"@natlibfi/melinda-commons": "^14.0.0",
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/melinda-backend-commons": "^3.0.1",
+				"@natlibfi/melinda-commons": "^14.0.1",
 				"debug": "^4.4.3",
 				"http-status": "^2.1.0"
 			},
@@ -961,26 +927,39 @@
 			}
 		},
 		"node_modules/@natlibfi/melinda-rest-api-commons": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-5.0.0.tgz",
-			"integrity": "sha512-ATKB0aDMN8RFMvzgISjP9f3k//rSWl78tW2VL3Nc2IbGCp40kgpMA5aNb8tm3puklUjeiOiOzHsUWyCf7jot4w==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-rest-api-commons/-/melinda-rest-api-commons-5.0.6.tgz",
+			"integrity": "sha512-9zDZxIrmKIYXXmPGha2cGQ7h1gh6YDi5YGglG02McdsdZL2/LKi7OekS5b0WHDzRZcPo0M0gy67kWoyV6ZJYIA==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.0",
-				"@natlibfi/marc-record-serializers": "^11.0.0",
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record-serializers": "^11.0.1",
 				"@natlibfi/marc-record-validate": "^9.0.0",
-				"@natlibfi/marc-record-validators-melinda": "^12.0.0",
-				"@natlibfi/melinda-backend-commons": "^3.0.0",
-				"@natlibfi/melinda-commons": "^14.0.0",
+				"@natlibfi/marc-record-validators-melinda": "^12.0.10",
+				"@natlibfi/melinda-backend-commons": "^3.0.4",
+				"@natlibfi/melinda-commons": "^14.0.2",
 				"amqplib": "^0.10.9",
 				"debug": "^4.4.3",
 				"http-status": "^2.1.0",
 				"moment": "^2.30.1",
 				"mongo-sanitize": "^1.1.0",
-				"mongodb": "^6.20.0"
+				"mongodb": "^6.21.0"
 			},
 			"engines": {
 				"node": ">=22"
+			}
+		},
+		"node_modules/@natlibfi/melinda-rest-api-commons/node_modules/amqplib": {
+			"version": "0.10.9",
+			"resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.9.tgz",
+			"integrity": "sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-more-ints": "~1.0.0",
+				"url-parse": "~1.5.10"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/@natlibfi/sfs-4900": {
@@ -993,30 +972,31 @@
 			}
 		},
 		"node_modules/@natlibfi/sru-client": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-7.0.0.tgz",
-			"integrity": "sha512-7W59fRH2gF2+YD21U+auMPxaW9OBlvPd/tkOXVqgq4uXvRjXPAHPz2qk7EEs5KK/L+LIbSxiOMYDxXyd4g78tw==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sru-client/-/sru-client-7.0.1.tgz",
+			"integrity": "sha512-L/lYCxUe6hFlvmqEunnipHa3tEb9qxVARCsB/U0bBNzTakYU6OCKE6Vv/p/N+H2Y0tUa3yLPpwkal8sLCSywnA==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.0",
-				"@natlibfi/marc-record-serializers": "^11.0.0",
-				"@natlibfi/melinda-backend-commons": "^3.0.0",
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record-serializers": "^11.0.1",
+				"@natlibfi/melinda-backend-commons": "^3.0.2",
 				"debug": "^4.4.3",
 				"http-status": "^2.1.0",
-				"xml2js": "^0.6.2"
+				"xml2js": "^0.6.2",
+				"yargs": "^18.0.0"
 			},
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@onify/fake-amqplib": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@onify/fake-amqplib/-/fake-amqplib-3.2.0.tgz",
-			"integrity": "sha512-pHOMdhbmxH7gbonDfClA4TB1Xh9xaBI7rF4CbhfcU7sFbPCTLU5T45fxRl6yfLcxAhrGQUTpGiT6RAKnilX4kA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@onify/fake-amqplib/-/fake-amqplib-3.4.0.tgz",
+			"integrity": "sha512-ZDLhpd7j0fbowp0muy1iWryj6sGrgEYt3Q5J2REQDvRVe4AQ8faTYvPSF41L3TM7R6+7g4jCovlag5p1ydufmA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"smqp": "^9.0.1"
+				"smqp": "^11.0.0"
 			},
 			"engines": {
 				"node": ">=14"
@@ -1070,6 +1050,13 @@
 				"text-hex": "1.0.x"
 			}
 		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1106,18 +1093,18 @@
 			}
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.9.8",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
-			"integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+			"version": "0.9.9",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
+			"integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.6"
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -1148,9 +1135,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1165,16 +1152,15 @@
 			}
 		},
 		"node_modules/amqplib": {
-			"version": "0.10.9",
-			"resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.9.tgz",
-			"integrity": "sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/amqplib/-/amqplib-1.0.2.tgz",
+			"integrity": "sha512-QFzavIs3FxXA9/PWOiY/j5Arr7KFT0b1TYYsq9f5PyZ3Dv5H5hQXTK3fZTUUzzOo2BF1o/Vk5bHAKzlL40LfDA==",
 			"license": "MIT",
 			"dependencies": {
-				"buffer-more-ints": "~1.0.0",
-				"url-parse": "~1.5.10"
+				"buffer-more-ints": "~1.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -1188,29 +1174,6 @@
 			"funding": {
 				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
-		},
-		"node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
-			"license": "Python-2.0"
 		},
 		"node_modules/async": {
 			"version": "3.2.6",
@@ -1228,17 +1191,10 @@
 				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/async-mutex/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"dev": true,
-			"license": "0BSD"
-		},
 		"node_modules/b4a": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+			"integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peerDependencies": {
@@ -1251,11 +1207,14 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/bare-events": {
 			"version": "2.8.2",
@@ -1272,6 +1231,88 @@
 				}
 			}
 		},
+		"node_modules/bare-fs": {
+			"version": "4.5.6",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.6.tgz",
+			"integrity": "sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-events": "^2.5.4",
+				"bare-path": "^3.0.0",
+				"bare-stream": "^2.6.4",
+				"bare-url": "^2.2.2",
+				"fast-fifo": "^1.3.2"
+			},
+			"engines": {
+				"bare": ">=1.16.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-os": {
+			"version": "3.8.6",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.6.tgz",
+			"integrity": "sha512-l8xaNWWb/bXuzgsrlF5jaa5QYDJ9S0ddd54cP6CH+081+5iPrbJiCfBWQqrWYzmUhCbsH+WR6qxo9MeHVCr0MQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"bare": ">=1.14.0"
+			}
+		},
+		"node_modules/bare-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-os": "^3.0.1"
+			}
+		},
+		"node_modules/bare-stream": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.11.0.tgz",
+			"integrity": "sha512-Y/+iQ49fL3rIn6w/AVxI/2+BRrpmzJvdWt5Jv8Za6Ngqc6V227c+pYjYYgLdpR3MwQ9ObVXD0ZrqoBztakM0rw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"streamx": "^2.25.0",
+				"teex": "^1.0.1"
+			},
+			"peerDependencies": {
+				"bare-abort-controller": "*",
+				"bare-buffer": "*",
+				"bare-events": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				},
+				"bare-buffer": {
+					"optional": true
+				},
+				"bare-events": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/bare-url": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+			"integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"bare-path": "^3.0.0"
+			}
+		},
 		"node_modules/base64-url": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.3.3.tgz",
@@ -1282,14 +1323,16 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/bson": {
@@ -1317,16 +1360,6 @@
 			"integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
 			"license": "MIT"
 		},
-		"node_modules/callsites": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/camelcase": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -1338,35 +1371,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/cld3-asm": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cld3-asm/-/cld3-asm-4.0.0.tgz",
-			"integrity": "sha512-eQq2detA7A54X9NSeunvHf4KcWlZKE/i98+V6NjWNDqF28GGk8Qk9XWApSywBjEcmPKR48zkabFWBoa1ExM/AQ==",
-			"license": "MIT",
-			"dependencies": {
-				"emscripten-wasm-loader": "^3.0.3"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/cliui": {
@@ -1392,43 +1396,33 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/collapse-white-space": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+			"integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/color": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
-			"integrity": "sha512-e2hz5BzbUPcYlIRHo8ieAhYgoajrJr+hWoceg6E345TPsATMUKqDgzt8fSXZJJbxfpiPzkWyphz8yn8At7q3fA==",
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+			"integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
 			"license": "MIT",
 			"dependencies": {
-				"color-convert": "^3.0.1",
-				"color-string": "^2.0.0"
+				"color-convert": "^3.1.3",
+				"color-string": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
-		"node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/color-string": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.2.tgz",
-			"integrity": "sha512-RxmjYxbWemV9gKu4zPgiZagUxbH3RQpEIO77XoSSX0ivgABDZ+h8Zuash/EMFLTI4N9QgFPOJ6JQpPZKFxa+dA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+			"integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "^2.0.0"
@@ -1438,18 +1432,18 @@
 			}
 		},
 		"node_modules/color-string/node_modules/color-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
-			"integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20"
 			}
 		},
 		"node_modules/color/node_modules/color-convert": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.2.tgz",
-			"integrity": "sha512-UNqkvCDXstVck3kdowtOTWROIJQwafjOfXSmddoDrXo4cewMKmusCeF22Q24zvjR8nwWib/3S/dfyzPItPEiJg==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+			"integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "^2.0.0"
@@ -1459,9 +1453,9 @@
 			}
 		},
 		"node_modules/color/node_modules/color-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
-			"integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+			"integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.20"
@@ -1474,17 +1468,10 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/core-js-pure": {
-			"version": "3.46.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.46.0.tgz",
-			"integrity": "sha512-NMCW30bHNofuhwLhYPt66OLOKTMbOhgTTatKVbaQC3KRHpTCiRIBYvtshr+NBYSnBxwAFhjW/RfJ0XbIjS16rw==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+			"integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -1629,20 +1616,6 @@
 			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
 			"license": "MIT"
 		},
-		"node_modules/emscripten-wasm-loader": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/emscripten-wasm-loader/-/emscripten-wasm-loader-3.0.3.tgz",
-			"integrity": "sha512-fyq2maBt5LOou27LEBlL5H6G04BxgSamXkvmMsAuIT6rd8ioH4BxNQhuyl6jVPeODh6U8Wk1BoFZxzHpg3o8wA==",
-			"license": "MIT",
-			"dependencies": {
-				"getroot": "^1.0.0",
-				"nanoid": "^2.0.3",
-				"unixify": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/enabled": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
@@ -1662,9 +1635,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
-			"integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+			"version": "0.27.4",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+			"integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -1675,32 +1648,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.0",
-				"@esbuild/android-arm": "0.27.0",
-				"@esbuild/android-arm64": "0.27.0",
-				"@esbuild/android-x64": "0.27.0",
-				"@esbuild/darwin-arm64": "0.27.0",
-				"@esbuild/darwin-x64": "0.27.0",
-				"@esbuild/freebsd-arm64": "0.27.0",
-				"@esbuild/freebsd-x64": "0.27.0",
-				"@esbuild/linux-arm": "0.27.0",
-				"@esbuild/linux-arm64": "0.27.0",
-				"@esbuild/linux-ia32": "0.27.0",
-				"@esbuild/linux-loong64": "0.27.0",
-				"@esbuild/linux-mips64el": "0.27.0",
-				"@esbuild/linux-ppc64": "0.27.0",
-				"@esbuild/linux-riscv64": "0.27.0",
-				"@esbuild/linux-s390x": "0.27.0",
-				"@esbuild/linux-x64": "0.27.0",
-				"@esbuild/netbsd-arm64": "0.27.0",
-				"@esbuild/netbsd-x64": "0.27.0",
-				"@esbuild/openbsd-arm64": "0.27.0",
-				"@esbuild/openbsd-x64": "0.27.0",
-				"@esbuild/openharmony-arm64": "0.27.0",
-				"@esbuild/sunos-x64": "0.27.0",
-				"@esbuild/win32-arm64": "0.27.0",
-				"@esbuild/win32-ia32": "0.27.0",
-				"@esbuild/win32-x64": "0.27.0"
+				"@esbuild/aix-ppc64": "0.27.4",
+				"@esbuild/android-arm": "0.27.4",
+				"@esbuild/android-arm64": "0.27.4",
+				"@esbuild/android-x64": "0.27.4",
+				"@esbuild/darwin-arm64": "0.27.4",
+				"@esbuild/darwin-x64": "0.27.4",
+				"@esbuild/freebsd-arm64": "0.27.4",
+				"@esbuild/freebsd-x64": "0.27.4",
+				"@esbuild/linux-arm": "0.27.4",
+				"@esbuild/linux-arm64": "0.27.4",
+				"@esbuild/linux-ia32": "0.27.4",
+				"@esbuild/linux-loong64": "0.27.4",
+				"@esbuild/linux-mips64el": "0.27.4",
+				"@esbuild/linux-ppc64": "0.27.4",
+				"@esbuild/linux-riscv64": "0.27.4",
+				"@esbuild/linux-s390x": "0.27.4",
+				"@esbuild/linux-x64": "0.27.4",
+				"@esbuild/netbsd-arm64": "0.27.4",
+				"@esbuild/netbsd-x64": "0.27.4",
+				"@esbuild/openbsd-arm64": "0.27.4",
+				"@esbuild/openbsd-x64": "0.27.4",
+				"@esbuild/openharmony-arm64": "0.27.4",
+				"@esbuild/sunos-x64": "0.27.4",
+				"@esbuild/win32-arm64": "0.27.4",
+				"@esbuild/win32-ia32": "0.27.4",
+				"@esbuild/win32-x64": "0.27.4"
 			}
 		},
 		"node_modules/escalade": {
@@ -1726,33 +1699,30 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.39.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
-			"integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
+			"integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
-				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.21.1",
-				"@eslint/config-helpers": "^0.4.2",
-				"@eslint/core": "^0.17.0",
-				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.39.1",
-				"@eslint/plugin-kit": "^0.4.1",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.3",
+				"@eslint/config-helpers": "^0.5.3",
+				"@eslint/core": "^1.1.1",
+				"@eslint/plugin-kit": "^0.6.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
 				"@types/estree": "^1.0.6",
-				"ajv": "^6.12.4",
-				"chalk": "^4.0.0",
+				"ajv": "^6.14.0",
 				"cross-spawn": "^7.0.6",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^8.4.0",
-				"eslint-visitor-keys": "^4.2.1",
-				"espree": "^10.4.0",
-				"esquery": "^1.5.0",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
 				"file-entry-cache": "^8.0.0",
@@ -1762,8 +1732,7 @@
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
-				"lodash.merge": "^4.6.2",
-				"minimatch": "^3.1.2",
+				"minimatch": "^10.2.4",
 				"natural-compare": "^1.4.0",
 				"optionator": "^0.9.3"
 			},
@@ -1771,7 +1740,7 @@
 				"eslint": "bin/eslint.js"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://eslint.org/donate"
@@ -1786,57 +1755,59 @@
 			}
 		},
 		"node_modules/eslint-scope": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/espree": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^4.2.1"
+				"eslint-visitor-keys": "^5.0.1"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -2073,9 +2044,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -2106,6 +2077,19 @@
 				}
 			}
 		},
+		"node_modules/franc": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/franc/-/franc-6.2.0.tgz",
+			"integrity": "sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==",
+			"license": "MIT",
+			"dependencies": {
+				"trigram-utils": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2116,28 +2100,15 @@
 			}
 		},
 		"node_modules/get-east-asian-width": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz",
-			"integrity": "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/getroot": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/getroot/-/getroot-1.0.0.tgz",
-			"integrity": "sha512-W9Q31kOv921dQuZBeAbK4R/dAPbC0WkhZD3alLcdVwjSkEtS1aX8twrzG3I5yo0sQ88M/d4JOqVbRiCuI/XPNA==",
-			"license": "MIT",
-			"dependencies": {
-				"tslib": "^1.7.1"
-			},
-			"engines": {
-				"node": ">=4.2.4",
-				"npm": ">=3.0.0"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -2151,29 +2122,6 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/globals": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/html-to-text": {
@@ -2244,23 +2192,6 @@
 				"node": ">= 4"
 			}
 		},
-		"node_modules/import-fresh": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"parent-module": "^1.0.0",
-				"resolve-from": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2320,9 +2251,9 @@
 			}
 		},
 		"node_modules/isbn3": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.0.tgz",
-			"integrity": "sha512-BOZkFfpkl60i0T0tnolwGNnPNrdCyfB0BgPFPVO5D0cMLiIknQ4p86XFDvWcWYzBEcalSl3SBrg40ECwbstMZA==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.6.tgz",
+			"integrity": "sha512-RrJy7jsXki4+QK/D2/ZH2lKi3oOr+xcgIMf2VXrDZ3DduE4awmu2XJ0Z/zu5j0L6XIGWbJUhe0UYD2BlRgwLrA==",
 			"license": "MIT",
 			"bin": {
 				"isbn": "bin/isbn",
@@ -2341,25 +2272,12 @@
 			"license": "ISC"
 		},
 		"node_modules/jose": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.1.1.tgz",
-			"integrity": "sha512-GWSqjfOPf4cWOkBzw5THBjtGPhXKqYnfRBzh4Ni+ArTrQQ9unvmsA3oFLqaYKoKe5sjWmGu5wVKg9Ft1i+LQfg==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+			"integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
-			}
-		},
-		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/json-buffer": {
@@ -2415,12 +2333,6 @@
 			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
 			"license": "MIT"
 		},
-		"node_modules/langs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/langs/-/langs-2.0.0.tgz",
-			"integrity": "sha512-v4pxOBEQVN1WBTfB1crhTtxzNLZU9HPWgadlwzWKISJtt6Ku/CnpBrwVy+jFv8StjxsPfwPFzO0CMwdZLJ0/BA==",
-			"license": "MIT"
-		},
 		"node_modules/leac": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
@@ -2461,16 +2373,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"license": "MIT"
-		},
-		"node_modules/lodash.merge": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-			"dev": true,
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
 			"license": "MIT"
 		},
 		"node_modules/logform": {
@@ -2523,16 +2428,19 @@
 			"license": "MIT"
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^5.0.2"
 			},
 			"engines": {
-				"node": "*"
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/moment": {
@@ -2551,9 +2459,9 @@
 			"license": "MIT"
 		},
 		"node_modules/mongodb": {
-			"version": "6.20.0",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
-			"integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+			"integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.3.0",
@@ -2607,14 +2515,14 @@
 			}
 		},
 		"node_modules/mongodb-memory-server": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.3.0.tgz",
-			"integrity": "sha512-dRNr2uEhMgjEe6kgqS+ITBKBbl2cz0DNBjNZ12BGUckvEOAHbhd3R7q/lFPSZrZ6AMKa2EOUJdAmFF1WlqSbsA==",
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.4.3.tgz",
+			"integrity": "sha512-CDZvFisXvGIigsIw5gqH6r9NI/zxGa/uRdutgUL/isuJh+inj0YXb7Ykw6oFMFzqgTJWb7x0I5DpzrqCstBWpg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"mongodb-memory-server-core": "10.3.0",
+				"mongodb-memory-server-core": "10.4.3",
 				"tslib": "^2.8.1"
 			},
 			"engines": {
@@ -2622,9 +2530,9 @@
 			}
 		},
 		"node_modules/mongodb-memory-server-core": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.3.0.tgz",
-			"integrity": "sha512-tp+ZfTBAPqHXjROhAFg6HcVVzXaEhh/iHcbY7QPOIiLwr94OkBFAw4pixyGSfP5wI2SZeEA13lXyRmBAhugWgA==",
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.4.3.tgz",
+			"integrity": "sha512-IPjlw73IoSYopnqBibQKxmAXMbOEPf5uGAOsBcaUiNH/TOI7V19WO+K7n5KYtnQ9FqzLGLpvwCGuPOTBSg4s5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2645,42 +2553,20 @@
 				"node": ">=16.20.1"
 			}
 		},
-		"node_modules/mongodb-memory-server-core/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"dev": true,
-			"license": "0BSD"
-		},
-		"node_modules/mongodb-memory-server/node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"dev": true,
-			"license": "0BSD"
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
-		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
+		"node_modules/n-gram": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
+			"integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
 			"license": "MIT",
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/natural-compare": {
@@ -2704,13 +2590,13 @@
 			}
 		},
 		"node_modules/nock": {
-			"version": "14.0.10",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-14.0.10.tgz",
-			"integrity": "sha512-Q7HjkpyPeLa0ZVZC5qpxBt5EyLczFJ91MEewQiIi9taWuA0KB/MDJlUWtON+7dGouVdADTQsf9RA7TZk6D8VMw==",
+			"version": "14.0.11",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-14.0.11.tgz",
+			"integrity": "sha512-u5xUnYE+UOOBA6SpELJheMCtj2Laqx15Vl70QxKo43Wz/6nMHXS7PrEioXLjXAwhmawdEMNImwKCcPhBJWbKVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@mswjs/interceptors": "^0.39.5",
+				"@mswjs/interceptors": "^0.41.0",
 				"json-stringify-safe": "^5.0.1",
 				"propagate": "^2.0.0"
 			},
@@ -2719,30 +2605,18 @@
 			}
 		},
 		"node_modules/nodemailer": {
-			"version": "7.0.10",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.10.tgz",
-			"integrity": "sha512-Us/Se1WtT0ylXgNFfyFSx4LElllVLJXQjWi2Xz17xWw7amDKO2MLtFnVp1WACy7GkVGs+oBlRopVNUzlrGSw1w==",
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
+			"integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
-			"license": "MIT",
-			"dependencies": {
-				"remove-trailing-separator": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/oauth4webapi": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.2.tgz",
-			"integrity": "sha512-FzZZ+bht5X0FKe7Mwz3DAVAmlH1BV5blSak/lHMBKz0/EBMhX6B10GlQYI51+oRp8ObJaX0g6pXrAxZh5s8rjw==",
+			"version": "3.8.5",
+			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.5.tgz",
+			"integrity": "sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -2758,13 +2632,13 @@
 			}
 		},
 		"node_modules/openid-client": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.1.tgz",
-			"integrity": "sha512-VoYT6enBo6Vj2j3Q5Ec0AezS+9YGzQo1f5Xc42lreMGlfP4ljiXPKVDvCADh+XHCV/bqPu/wWSiCVXbJKvrODw==",
+			"version": "6.8.2",
+			"resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.2.tgz",
+			"integrity": "sha512-uOvTCndr4udZsKihJ68H9bUICrriHdUVJ6Az+4Ns6cW55rwM5h0bjVIzDz2SxgOI84LKjFyjOFvERLzdTUROGA==",
 			"license": "MIT",
 			"dependencies": {
-				"jose": "^6.1.0",
-				"oauth4webapi": "^3.8.2"
+				"jose": "^6.1.3",
+				"oauth4webapi": "^3.8.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -2833,19 +2707,6 @@
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/parent-module": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"callsites": "^3.0.0"
-			},
 			"engines": {
 				"node": ">=6"
 			}
@@ -3017,27 +2878,11 @@
 				"node": ">= 6"
 			}
 		},
-		"node_modules/remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
-			"license": "ISC"
-		},
 		"node_modules/requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
 			"license": "MIT"
-		},
-		"node_modules/resolve-from": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -3069,10 +2914,13 @@
 			}
 		},
 		"node_modules/sax": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-			"integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-			"license": "BlueOak-1.0.0"
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
 		},
 		"node_modules/selderee": {
 			"version": "0.11.0",
@@ -3087,9 +2935,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3123,9 +2971,9 @@
 			}
 		},
 		"node_modules/smqp": {
-			"version": "9.0.6",
-			"resolved": "https://registry.npmjs.org/smqp/-/smqp-9.0.6.tgz",
-			"integrity": "sha512-NMtu5d8d86Xz/t17Ut79phTqrHB8SuQwHtZA2tqWN5HxrxtyfSlk3aMIWTqYXaFOjqV2fKQBJPPsMHXcrYZc/w==",
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/smqp/-/smqp-11.0.1.tgz",
+			"integrity": "sha512-sMm/kimL7vzjY14wzJgFgf7ypPKP6vO4D+ZyLVpKPts3O42Pxysy2AXQMM4JiOS6uFpOHIbuPH1SvDj2mEOHcw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3163,9 +3011,9 @@
 			}
 		},
 		"node_modules/streamx": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+			"integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3208,12 +3056,12 @@
 			}
 		},
 		"node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^6.0.1"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
 				"node": ">=12"
@@ -3222,48 +3070,33 @@
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
-		"node_modules/strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/tar-stream": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+			"integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
 				"fast-fifo": "^1.2.0",
 				"streamx": "^2.15.0"
 			}
 		},
+		"node_modules/teex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"streamx": "^2.12.5"
+			}
+		},
 		"node_modules/text-decoder": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+			"integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3288,6 +3121,20 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/trigram-utils": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-2.0.1.tgz",
+			"integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
+			"license": "MIT",
+			"dependencies": {
+				"collapse-white-space": "^2.0.0",
+				"n-gram": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/triple-beam": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -3298,9 +3145,10 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/type-check": {
@@ -3314,27 +3162,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/undici": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
-			"integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.18.1"
-			}
-		},
-		"node_modules/unixify": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
-			"integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
-			"license": "MIT",
-			"dependencies": {
-				"normalize-path": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/uri-js": {
@@ -3415,9 +3242,9 @@
 			}
 		},
 		"node_modules/winston": {
-			"version": "3.18.3",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-3.18.3.tgz",
-			"integrity": "sha512-NoBZauFNNWENgsnC9YpgyYwOVrl2m58PpQ8lNHjV3kosGs7KJ7Npk9pCUE+WJlawVSe8mykWDKWFSVfs3QO9ww==",
+			"version": "3.19.0",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+			"integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
 			"license": "MIT",
 			"dependencies": {
 				"@colors/colors": "^1.6.0",
@@ -3556,9 +3383,9 @@
 			}
 		},
 		"node_modules/yauzl": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
-			"integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
+			"integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-import-importer.git"
 	},
 	"license": "MIT",
-	"version": "1.0.7",
+	"version": "1.0.8-alpha.3",
 	"main": "./dist/index.js",
 	"type": "module",
 	"bin": "./dist/cli.js",
@@ -34,25 +34,26 @@
 		"dev:debug": "cross-env LOG_LEVEL=debug DEBUG=@natlibfi/* NODE_ENV=test npm run watch:test"
 	},
 	"dependencies": {
-		"@natlibfi/marc-record": "^10.0.0",
-		"@natlibfi/melinda-backend-commons": "^3.0.0",
-		"@natlibfi/melinda-commons": "^14.0.0",
-		"@natlibfi/melinda-record-import-commons": "^13.0.0",
-		"@natlibfi/melinda-rest-api-client": "^6.0.0",
-		"@natlibfi/melinda-rest-api-commons": "^5.0.0",
-		"amqplib": "^0.10.9",
+		"@natlibfi/marc-record": "^10.0.1",
+		"@natlibfi/melinda-backend-commons": "^3.0.5",
+		"@natlibfi/melinda-commons": "^14.0.2",
+		"@natlibfi/melinda-record-import-commons": "^13.0.3",
+		"@natlibfi/melinda-rest-api-client": "^6.0.3",
+		"@natlibfi/melinda-rest-api-commons": "^5.0.6",
+		"amqplib": "^1.0.2",
+		"debug": "^4.4.3",
 		"http-status": "^2.1.0"
 	},
 	"devDependencies": {
-		"@natlibfi/fixugen": "^3.0.0",
-		"@natlibfi/fixugen-http-client": "^4.0.0",
-		"@natlibfi/fixura": "^4.0.0",
-		"@natlibfi/fixura-mongo": "^3.0.0",
-		"@onify/fake-amqplib": "^3.2.0",
+		"@natlibfi/fixugen": "^3.0.1",
+		"@natlibfi/fixugen-http-client": "^4.0.3",
+		"@natlibfi/fixura": "^4.0.1",
+		"@natlibfi/fixura-mongo": "^3.0.3",
+		"@onify/fake-amqplib": "^3.4.0",
 		"cross-env": "^10.1.0",
-		"esbuild": "^0.27.0",
-		"eslint": "^9.39.1",
-		"nock": "^14.0.10"
+		"esbuild": "^0.27.4",
+		"eslint": "^10.1.0",
+		"nock": "^14.0.11"
 	},
 	"overrides": {
 		"nanoid": "^3.3.8"


### PR DESCRIPTION
* Bump the production-dependencies group with 6 updates (#153)

Updates `@natlibfi/marc-record` from 10.0.0 to 10.0.1 Updates `@natlibfi/melinda-backend-commons` from 3.0.0 to 3.0.5 Updates `@natlibfi/melinda-commons` from 14.0.0 to 14.0.2 Updates `@natlibfi/melinda-record-import-commons` from 13.0.0 to 13.0.3 Updates `@natlibfi/melinda-rest-api-client` from 6.0.0 to 6.0.3 Updates `@natlibfi/melinda-rest-api-commons` from 5.0.0 to 5.0.6

* Bump nodemailer and @natlibfi/melinda-backend-commons (#156) Updates `nodemailer` from 7.0.10 to 8.0.4
Updates `@natlibfi/melinda-backend-commons` from 3.0.0 to 3.0.5

* Bump yauzl from 3.2.0 to 3.2.1 (#160) Bumps [yauzl](https://github.com/thejoshwolfe/yauzl) from 3.2.0 to 3.2.1.

* Bump lodash from 4.17.21 to 4.17.23 (#158) Bumps [lodash](https://github.com/lodash/lodash) from 4.17.21 to 4.17.23.

* Bump js-yaml from 4.1.0 to 4.1.1 (#161) Bumps [js-yaml](https://github.com/nodeca/js-yaml) from 4.1.0 to 4.1.1.

* Bump minimatch from 3.1.2 to 3.1.5 (#157) Bumps [minimatch](https://github.com/isaacs/minimatch) from 3.1.2 to 3.1.5.

* Bump flatted from 3.3.3 to 3.4.2 (#155) Bumps [flatted](https://github.com/WebReflection/flatted) from 3.3.3 to 3.4.2.

* Bump actions/checkout from 5 to 6 (#151) Bumps [actions/checkout](https://github.com/actions/checkout) from 5 to 6.

* Update amqplib v1.0.2

* Update deps

* Update copyright year

* 1.0.8-alpha.3